### PR TITLE
rename std-{log,out,err} -> ext-{log,out,err}

### DIFF
--- a/config/htcanalyze.conf
+++ b/config/htcanalyze.conf
@@ -9,11 +9,11 @@
 
 files = [check-the-htcanalyze.conf]
 
-# if std-log is not set, every file will be interpreted as a log file,
-# except std-err and std-out files
-# std-log = ''
-std-err = .err
-std-out = .out
+# if ext-log is not set, every file will be interpreted as a log file,
+# except ext-err and ext-out files
+# ext-log = ''
+ext-err = .err
+ext-out = .out
 
 # only for default and analyze mode
 show = []

--- a/htcanalyze/htcanalyze.py
+++ b/htcanalyze/htcanalyze.py
@@ -37,9 +37,9 @@ class HTCAnalyze:
     """
 
     def __init__(self,
-                 std_log="",
-                 std_err=".err",
-                 std_out=".out",
+                 ext_log="",
+                 ext_err=".err",
+                 ext_out=".out",
                  show_list=None,
                  reverse_dns_lookup=None,
                  tolerated_usage=None,
@@ -50,17 +50,17 @@ class HTCAnalyze:
         The None defaults are necessary,
         cause None should be handled correctly if given
 
-        :param std_log:
-        :param std_err:
-        :param std_out:
+        :param ext_log:
+        :param ext_err:
+        :param ext_out:
         :param show_list:
         :param reverse_dns_lookup:
         :param tolerated_usage:
         :param bad_usage:
         """
-        self.std_log = std_log
-        self.std_err = std_err
-        self.std_out = std_out
+        self.ext_log = ext_log
+        self.ext_err = ext_err
+        self.ext_out = ext_out
         if show_list is None:
             self.show_list = []
         else:
@@ -150,13 +150,13 @@ class HTCAnalyze:
         except NameError as err:
             logging.exception(err)
             rprint("[red]The smart_output_error method requires a " +
-                   self.std_err + " file as parameter[/red]")
+                   self.ext_err + " file as parameter[/red]")
         except FileNotFoundError:
             relevant = file.split("/")[-2:]
             match = re.match(r".*?([0-9]{3,}_[0-9]+)" +
-                             self.std_err, relevant[1])
+                             self.ext_err, relevant[1])
             rprint(
-                f"[yellow]There is no related {self.std_err} file:"
+                f"[yellow]There is no related {self.ext_err} file:"
                 f" {relevant[1]} in the directory:\n[/yellow]"
                 f"[cyan]'{os.path.abspath(relevant[0])}'\n"
                 f" with the prefix: {match[1]}[/cyan]")
@@ -183,12 +183,12 @@ class HTCAnalyze:
         except NameError as err:
             logging.exception(err)
             rprint("[red]The smart_output_output method requires a " +
-                   self.std_out + " file as parameter[/red]")
+                   self.ext_out + " file as parameter[/red]")
         except FileNotFoundError:
             relevant = file.split("/")[-2:]
             match = re.match(r".*?([0-9]{3,}_[0-9]+)" +
-                             self.std_out, relevant[1])
-            rprint(f"[yellow]There is no related {self.std_out}"
+                             self.ext_out, relevant[1])
+            rprint(f"[yellow]There is no related {self.ext_out}"
                    f" file: {relevant[1]} in the directory:\n"
                    f"[/yellow][cyan]'{os.path.abspath(relevant[0])}'\n"
                    f" with the prefix: {match[1]}[/cyan]")
@@ -208,12 +208,12 @@ class HTCAnalyze:
         get_job_spec_id("43221_23.log", ".log") -> "43221_23"
 
         :param file:
-        :param std_log:
+        :param ext_log:
         :return: file prefix
         """
-        if self.std_log.__ne__("") \
-                and file[-len(self.std_log):].__eq__(self.std_log):
-            job_spec_id = file[:-len(self.std_log)]
+        if self.ext_log.__ne__("") \
+                and file[-len(self.ext_log):].__eq__(self.ext_log):
+            job_spec_id = file[:-len(self.ext_log)]
         else:
             job_spec_id = os.path.splitext(file)[0]
         return job_spec_id
@@ -526,10 +526,10 @@ class HTCAnalyze:
                 job_spec_id = self.get_job_spec_id(file)
                 if 'std-err' in self.show_list:
                     result_dict['stderr'] = self.htcondor_stderr(
-                        job_spec_id + self.std_err)
+                        job_spec_id + self.ext_err)
                 if 'std-out' in self.show_list:
                     result_dict['stdout'] = self.htcondor_stdout(
-                        job_spec_id + self.std_out)
+                        job_spec_id + self.ext_out)
 
             list_of_dicts.append(result_dict)
 
@@ -623,10 +623,10 @@ class HTCAnalyze:
                     job_spec_id = self.get_job_spec_id(file)
                     if 'std-err' in self.show_list:
                         result_dict['stderr'] = self.htcondor_stderr(
-                            job_spec_id + self.std_err)
+                            job_spec_id + self.ext_err)
                     if 'std-out' in self.show_list:
                         result_dict['stdout'] = self.htcondor_stdout(
-                            job_spec_id + self.std_out)
+                            job_spec_id + self.ext_out)
 
                 result_list.append(result_dict)
 

--- a/htcanalyze/logvalidator.py
+++ b/htcanalyze/logvalidator.py
@@ -18,14 +18,14 @@ class LogValidator:
     """
 
     def __init__(self,
-                 std_log="",
-                 std_err=".err",
-                 std_out=".out",
+                 ext_log="",
+                 ext_err=".err",
+                 ext_out=".out",
                  recursive=False):
         """Initialize."""
-        self.std_log = std_log
-        self.std_err = std_err
-        self.std_out = std_out
+        self.ext_log = ext_log
+        self.ext_err = ext_err
+        self.ext_out = ext_out
         self.recursive = recursive
 
     def validate_file(self, file) -> bool:
@@ -35,14 +35,14 @@ class LogValidator:
         :param file: HTCondor log file
         :return: True when valid else False
         """
-        # if not ending with stdout
-        if self.std_log.__ne__("") and not file.endswith(self.std_log):
+        # if not ending with extout
+        if self.ext_log.__ne__("") and not file.endswith(self.ext_log):
             return False
 
-        # does also not end with sterr and stdout suffix
-        if self.std_err.__ne__("") and file.endswith(self.std_err):
+        # does also not end with exterr and extout suffix
+        if self.ext_err.__ne__("") and file.endswith(self.ext_err):
             return False
-        if self.std_out.__ne__("") and file.endswith(self.std_out):
+        if self.ext_out.__ne__("") and file.endswith(self.ext_out):
             return False
 
         if os.path.getsize(file) == 0:  # file is empty
@@ -88,10 +88,10 @@ class LogValidator:
             if file.startswith(".") or file.startswith("__"):
                 continue
 
-            # if std_log is set, ignore other log files
-            if self.std_log.__ne__("") and not file.endswith(self.std_log):
+            # if ext_log is set, ignore other log files
+            if self.ext_log.__ne__("") and not file.endswith(self.ext_log):
                 logging.debug("Ignoring this file, " + file +
-                              ", because std-log is: " + self.std_log)
+                              ", because ext-log is: " + self.ext_log)
                 continue
 
             # backslash handling
@@ -152,11 +152,11 @@ class LogValidator:
                 elif os.path.isfile(logs_path):
                     working_file_path = logs_path
                 # check if only the id was given
-                # and resolve it with the std_log specification
-                elif os.path.isfile(arg + self.std_log):
-                    working_file_path = arg + self.std_log
-                elif os.path.isfile(logs_path + self.std_log):
-                    working_file_path = logs_path + self.std_log
+                # and resolve it with the ext_log specification
+                elif os.path.isfile(arg + self.ext_log):
+                    working_file_path = arg + self.ext_log
+                elif os.path.isfile(logs_path + self.ext_log):
+                    working_file_path = logs_path + self.ext_log
 
                 # if path is a directory
                 if working_dir_path.__ne__(""):

--- a/htcanalyze/main.py
+++ b/htcanalyze/main.py
@@ -258,13 +258,13 @@ def setup_commandline_parser(default_config_files=[])\
                              " combine with -s for analyzed-summary mode",
                         action="store_true")
 
-    parser.add_argument("--std-log",
+    parser.add_argument("--ext-log",
                         help="Specify the log file suffix",
                         type=str)
-    parser.add_argument("--std-out",
+    parser.add_argument("--ext-out",
                         help="Specify the output file suffix",
                         type=str)
-    parser.add_argument("--std-err",
+    parser.add_argument("--ext-err",
                         help="Specify the error file suffix",
                         type=str)
 
@@ -345,9 +345,9 @@ def manage_params(args: list) -> dict:
      {'verbose': False,
       'generate_log_file': None,
       'mode': None,
-      'std_log': '',
-      'std_out': '.out',
-      'std_err': '.err',
+      'ext_log': '',
+      'ext_out': '.out',
+      'ext_err': '.err',
       'ignore_list': [],
       'show_list': [],
       'no_config': False,
@@ -480,12 +480,12 @@ def manage_params(args: list) -> dict:
     del cmd_dict["version"]
     del cmd_dict["no_config"]
 
-    if cmd_dict['std_log'] is None:
-        cmd_dict['std_log'] = ""
-    if cmd_dict['std_err'] is None:
-        cmd_dict['std_err'] = ".err"
-    if cmd_dict['std_out'] is None:
-        cmd_dict['std_out'] = ".out"
+    if cmd_dict['ext_log'] is None:
+        cmd_dict['ext_log'] = ""
+    if cmd_dict['ext_err'] is None:
+        cmd_dict['ext_err'] = ".err"
+    if cmd_dict['ext_out'] is None:
+        cmd_dict['ext_out'] = ".out"
 
     return cmd_dict
 
@@ -678,9 +678,9 @@ def run(commandline_args):
         logging.debug("-------Start of htcanalyze script-------")
 
         htcanalyze = \
-            HTCAnalyze(std_log=param_dict["std_log"],
-                        std_out=param_dict["std_out"],
-                        std_err=param_dict["std_err"],
+            HTCAnalyze(ext_log=param_dict["ext_log"],
+                        ext_out=param_dict["ext_out"],
+                        ext_err=param_dict["ext_err"],
                         show_list=param_dict["show_list"],
                         reverse_dns_lookup=param_dict["reverse_dns_lookup"],
                         tolerated_usage=param_dict["tolerated_usage"],
@@ -694,9 +694,9 @@ def run(commandline_args):
         if GlobalServant.redirecting_stdout:
             logging.debug("Output is getting redirected")
 
-        validator = LogValidator(std_log=param_dict["std_log"],
-                                 std_out=param_dict["std_out"],
-                                 std_err=param_dict["std_err"],
+        validator = LogValidator(ext_log=param_dict["ext_log"],
+                                 ext_out=param_dict["ext_out"],
+                                 ext_err=param_dict["ext_err"],
                                  recursive=param_dict["recursive"])
 
         valid_files = validator.common_validation(param_dict["files"])

--- a/htcanalyze/main.py
+++ b/htcanalyze/main.py
@@ -259,13 +259,13 @@ def setup_commandline_parser(default_config_files=[])\
                         action="store_true")
 
     parser.add_argument("--ext-log",
-                        help="Specify the log file suffix",
+                        help="Suffix of HTCondor job logs (default: none)",
                         type=str)
     parser.add_argument("--ext-out",
-                        help="Specify the output file suffix",
+                        help="Suffix of job out logs (default: .out)",
                         type=str)
     parser.add_argument("--ext-err",
-                        help="Specify the error file suffix",
+                        help="Suffix of job error logs (default: .err)",
                         type=str)
 
     ignore_metavar = "{" + ALLOWED_IGNORE_VALUES[0] + " ... " \

--- a/man/man1/htcanalyze.1
+++ b/man/man1/htcanalyze.1
@@ -16,9 +16,9 @@
 .Op Fl Fl mode Ar mode
 .Op Fl Fl version
 .Op Fl Fl verbose
-.Op Fl Fl std-log Ar suffix
-.Op Fl Fl std-out Ar suffix
-.Op Fl Fl std-err Ar suffix
+.Op Fl Fl ext-log Ar suffix
+.Op Fl Fl ext-out Ar suffix
+.Op Fl Fl ext-err Ar suffix
 .Op Fl Fl ignore Ar keywords
 .Op Fl Fl show-more Ar keywords
 .Op Fl c Ar config
@@ -162,21 +162,21 @@ Examples:
 --filter error warnings --mode analyze
 .Ed
 .
-.It Fl Fl std-log Ar standard-log
+.It Fl Fl ext-log Ar suffix
 The standard log files usually look something like
 .Qq job_452_237.log ,
 if for whatever reason the format is not
 .Qq .log ,
 then you can change it with this argument.
 .
-.It Fl Fl std-err Ar standard-err
+.It Fl Fl ext-err Ar suffix
 The standard error files usually look something like
 .Qq job_452_237.err ,
 if for whatever reason the format is not
 .Qq .err ,
 then you can change it with this argument.
 .
-.It Fl Fl std-out Ar standard-out
+.It Fl Fl ext-out Ar suffix
 The standard output files usually look something like
 .Qq job_452_237.out ,
 if for whatever reason the format is not

--- a/man/man1/htcanalyze.1
+++ b/man/man1/htcanalyze.1
@@ -163,25 +163,22 @@ Examples:
 .Ed
 .
 .It Fl Fl ext-log Ar suffix
-The standard log files usually look something like
-.Qq job_452_237.log ,
-if for whatever reason the format is not
-.Qq .log ,
-then you can change it with this argument.
+The suffix to filter for HTCondor log files.
+The default attempts to parse all files that don't end in the
+.It Fl Fl ext-err
+or
+.It Fl Fl ext-out
+suffixes.
 .
 .It Fl Fl ext-err Ar suffix
-The standard error files usually look something like
-.Qq job_452_237.err ,
-if for whatever reason the format is not
-.Qq .err ,
-then you can change it with this argument.
+The suffix to filter for HTCondor error files.
+Defaults to
+.Qq .err .
 .
 .It Fl Fl ext-out Ar suffix
-The standard output files usually look something like
-.Qq job_452_237.out ,
-if for whatever reason the format is not
-.Qq .out ,
-then you can change it with this argument.
+The suffix to filter for HTCondor out files.
+Defaults to
+.Qq .out .
 .
 .It Fl Fl show-more Ar keywords
 show information inside the (if generated) stdout and stderr files,

--- a/tests/coverage_test.py
+++ b/tests/coverage_test.py
@@ -95,7 +95,7 @@ def test_wrong_opts_or_args():
 
     # Argument starts with -,
     # this will not raise an error, but is considered sceptical
-    args = "--std-log -log".split()
+    args = "--ext-log -log".split()
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         ht.run(args)
     assert pytest_wrapped_e.type == SystemExit
@@ -134,15 +134,15 @@ def test_ignore_values():
 
 
 def test_independent_opts():
-    args = "--std-log=.log --std-out=.output " \
-           "--std-err=.error --reverse-dns-lookup".split()
+    args = "--ext-log=.log --ext-out=.output " \
+           "--ext-err=.error --reverse-dns-lookup".split()
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         ht.run(args)
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1  # no valid file is given
 
-    args = "--std-log log --std-out output " \
-           "--std-err error " \
+    args = "--ext-log log --ext-out output " \
+           "--ext-err error " \
            "--reverse-dns-lookup tests/test_logs/valid_logs".split()
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         ht.run(args)

--- a/tests/htcanalyze_test.py
+++ b/tests/htcanalyze_test.py
@@ -151,9 +151,9 @@ def htcan():
 
 
 def test_HTCAnalyze_init(htcan):
-    assert htcan.std_log == ""
-    assert htcan.std_err == ".err"
-    assert htcan.std_out == ".out"
+    assert htcan.ext_log == ""
+    assert htcan.ext_err == ".err"
+    assert htcan.ext_out == ".out"
     assert htcan.show_list == []
     assert htcan.store_dns_lookups == {}
     assert htcan.reverse_dns_lookup is False

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -66,11 +66,11 @@ def test_manage_params():
     assert pytest_wrapped_e.value.code == 0
 
     # normal parameters
-    args = "--std-log=.logging --std-out=.output --std-err=.error".split()
+    args = "--ext-log=.logging --ext-out=.output --ext-err=.error".split()
     res_dict = ht.manage_params(args)
-    assert res_dict["std_log"] == ".logging"
-    assert res_dict["std_out"] == ".output"
-    assert res_dict["std_err"] == ".error"
+    assert res_dict["ext_log"] == ".logging"
+    assert res_dict["ext_out"] == ".output"
+    assert res_dict["ext_err"] == ".error"
 
     args = "--show std-err std-out --ignore execution-details " \
            "times errors host-nodes used-resources " \

--- a/tests/test_configs/valid_configs/all_params_set.conf
+++ b/tests/test_configs/valid_configs/all_params_set.conf
@@ -5,9 +5,9 @@ files = tests/test-logs/valid-logs
 table-format = pretty
 
 [htc-files]
-std-log = .log
-std-err = .err
-std-out = .out
+ext-log = .log
+ext-err = .err
+ext-out = .out
 
 # only for default mode
 [show-more]


### PR DESCRIPTION
I found the word "standard" to be confusing, especially as there is no "standard log". This changes to "ext" (short for a file "extension").

The help text and man page has also been updated to reflect this, and clarify the default behavior.