### PR TITLE
Add unhandled events

### DIFF
--- a/htcanalyze/log_analyzer/condor_log/ram_history.py
+++ b/htcanalyze/log_analyzer/condor_log/ram_history.py
@@ -35,7 +35,10 @@ class RamHistory(ReprObject):
         :param show_legend: Shows a legend
         :return: str
         """
-        ram = [ram.size_update for ram in self.image_size_events]
+        ram = [
+            ram.size_update/1000  # convert to MB
+            for ram in self.image_size_events
+        ]
         dates = [ram.time_stamp for ram in self.image_size_events]
         if len(ram) == 0:
             return ""  # No memory usage detected
@@ -44,7 +47,7 @@ class RamHistory(ReprObject):
             return str(
                 f"Single memory update found:\n"
                 f"Memory usage on the {dates[0]} "
-                f"was updatet to {ram[0]} MB\n"
+                f"was updated to {ram[0]} MB\n"
             )
 
         # else
@@ -54,7 +57,7 @@ class RamHistory(ReprObject):
         fig.set_x_limits(min_=min(dates))
         min_ram = int(min(ram))  # raises error if not casted
         fig.set_y_limits(min_=min_ram)
-        fig.y_label = "Usage (KB)"
+        fig.y_label = "Usage [MB]"
         fig.x_label = "Time"
 
         # this will use the self written function _

--- a/htcanalyze/log_analyzer/event_handler/event_handler.py
+++ b/htcanalyze/log_analyzer/event_handler/event_handler.py
@@ -51,17 +51,48 @@ class ReadLogException(Exception):
     """Can't read log file exception."""
 
 
-class HTCJobEventWrapper(HTCJobEvent):
-    """Wrapper for HTCJobEvent."""
+class HTCJobEventWrapper:
+    """
+    Wrapper for HTCondor JobEvent.
 
-    def __new__(cls, job_event: HTCJobEvent):
-        new = job_event
-        new.event_number = job_event.get('EventTypeNumber')
-        new.time_stamp = date_time.strptime(
-            job_event.get('EventTime'),
-            STRP_FORMAT
+    Extracts event number and time_stamp of an event.
+    The wrapped event can be printed to the terminal for dev purpose.
+
+    :param job_event: HTCJobEvent
+    """
+
+    def __init__(self, job_event: HTCJobEvent):
+
+        self.wrapped_class = job_event
+        self.event_number = job_event.get('EventTypeNumber')
+        self.time_stamp = date_time.strptime(
+                job_event.get('EventTime'),
+                STRP_FORMAT
+            )
+
+    def __getattr__(self, attr):
+        return getattr(self.wrapped_class, attr)
+
+    def get(self, *args, **kwargs):
+        return self.wrapped_class.get(*args, **kwargs)
+
+    def items(self):
+        return self.wrapped_class.items()
+
+    def keys(self):
+        return self.wrapped_class.keys()
+
+    def values(self):
+        return self.wrapped_class.values()
+
+    def to_dict(self):
+        return {key: val for key, val in self.items()}
+
+    def __repr__(self):
+        return json.dumps(
+            self.to_dict(),
+            indent=2
         )
-        return new
 
 
 class EventHandler:

--- a/htcanalyze/log_analyzer/event_handler/event_handler.py
+++ b/htcanalyze/log_analyzer/event_handler/event_handler.py
@@ -69,7 +69,6 @@ class HTCJobEventWrapper:
     """
 
     def __init__(self, job_event: HTCJobEvent):
-
         self.wrapped_class = job_event
         self.event_number = job_event.get('EventTypeNumber')
         self.time_stamp = date_time.strptime(
@@ -81,19 +80,24 @@ class HTCJobEventWrapper:
         return getattr(self.wrapped_class, attr)
 
     def get(self, *args, **kwargs):
+        """Wraps wrapped_class get function."""
         return self.wrapped_class.get(*args, **kwargs)
 
     def items(self):
+        """Wraps wrapped_class items method."""
         return self.wrapped_class.items()
 
     def keys(self):
+        """Wraps wrapped_class keys method."""
         return self.wrapped_class.keys()
 
     def values(self):
+        """Wraps wrapped_class values method."""
         return self.wrapped_class.values()
 
     def to_dict(self):
-        return {key: val for key, val in self.items()}
+        """Turns wrapped_class items into a dictionary."""
+        return dict(self.items())
 
     def __repr__(self):
         return json.dumps(
@@ -217,10 +221,8 @@ class EventHandler:
             )
         )
 
-        normal_termination = event.get('TerminatedNormally')
-
         # differentiate between normal and abnormal termination
-        if normal_termination:
+        if event.get('TerminatedNormally'):
             self._state = NormalTerminationState()
             return_value = event.get('ReturnValue')
             return NormalTerminationEvent(
@@ -229,16 +231,16 @@ class EventHandler:
                 resources,
                 return_value
             )
-        else:
-            return_value = event.get('TerminatedBySignal')
-            self._state = AbnormalTerminationState()
-            return AbnormalTerminationEvent(
-                event.event_number,
-                event.time_stamp,
-                resources,
-                return_value
-            )
-            # Todo: include description when possible
+        # else:
+        return_value = event.get('TerminatedBySignal')
+        self._state = AbnormalTerminationState()
+        return AbnormalTerminationEvent(
+            event.event_number,
+            event.time_stamp,
+            resources,
+            return_value
+        )
+        # Todo: include description when possible
 
     @staticmethod
     def get_job_evicted_event(
@@ -325,6 +327,7 @@ class EventHandler:
     def get_job_disconnected_event(
             event: HTCJobEventWrapper
     ) -> JobDisconnectedEvent:
+        """Reads and returns a JobDisconnectedEvent."""
         assert event.type == jet.JOB_DISCONNECTED
         reason = f"{event.get('DisconnectReason')}"
         return JobDisconnectedEvent(
@@ -337,18 +340,18 @@ class EventHandler:
     def get_job_reconnected_event(
             event: HTCJobEventWrapper
     ) -> JobReconnectedEvent:
+        """Reads and returns a JobReconnectedEvent."""
         assert event.type == jet.JOB_RECONNECTED
-        reason = f"{event.get('Reason')}"
         return JobReconnectedEvent(
             event.event_number,
             event.time_stamp,
-            reason
         )
 
     @staticmethod
     def get_job_reconnect_failed_event(
             event: HTCJobEventWrapper
     ) -> JobReconnectFailedEvent:
+        """Reads and returns a JobReconnectFailedEvent."""
         assert event.type == jet.JOB_RECONNECT_FAILED
         reason = f"{event.get('Reason')}"
         return JobReconnectFailedEvent(

--- a/htcanalyze/log_analyzer/event_handler/job_events.py
+++ b/htcanalyze/log_analyzer/event_handler/job_events.py
@@ -450,6 +450,17 @@ class JobHeldEvent(ErrorEvent):
         )
 
 
+class JobReleasedEvent(JobEvent):
+    """
+    Job was released after being hold event.
+
+    Event Number: 013
+    Event Name: Job was released
+    Event Description: The job was in the hold state and is to be re-run.
+
+    """
+
+
 class JobDisconnectedEvent(ErrorEvent):
     """
     Job disconnected event.

--- a/htcanalyze/log_analyzer/event_handler/job_events.py
+++ b/htcanalyze/log_analyzer/event_handler/job_events.py
@@ -187,7 +187,7 @@ class JobCheckpointedEvent(JobEvent):
 
     Event Number: 003
     Event Name: Job was checkpointed
-    Event Description: The job’s complete state was written to a checkpoint 
+    Event Description: The job’s complete state was written to a checkpoint
         file. This might happen without the job being removed from a machine,
         because the checkpointing can happen periodically.
 

--- a/htcanalyze/log_analyzer/event_handler/states.py
+++ b/htcanalyze/log_analyzer/event_handler/states.py
@@ -86,39 +86,36 @@ class RunningState(ExecutionState):
 class ErrorState(State, ABC):
     """Represents an error state."""
 
-    def __init__(self):
+    def __init__(self, name=None):
+        self.name = name
         self.color = "red"
 
 
 class ErrorWhileReadingState(JobState, ErrorState):
     """Represents an error while reading state."""
     def __init__(self):
-        super().__init__()
-        self.name = "ERROR_WHILE_READING"
+        super().__init__("ERROR_WHILE_READING")
 
 
 class InvalidHostAddressState(ErrorState):
     """Represents an invalid host address state."""
 
     def __init__(self):
-        super().__init__()
-        self.name = "INVALID_HOST_ADDRESS"
+        super().__init__("INVALID_HOST_ADDRESS")
 
 
 class InvalidUserAddressState(ErrorState):
     """Represents an invalid user address state."""
 
     def __init__(self):
-        super().__init__()
-        self.name = "INVALID_USER_ADDRESS"
+        super().__init__("INVALID_USER_ADDRESS")
 
 
 class AbortedState(TerminationState, ErrorState):
     """Represents an abortion state."""
 
     def __init__(self):
-        super().__init__()
-        self.name = "ABORTED"
+        super().__init__("ABORTED")
 
 
 class JobHeldState(ErrorState):
@@ -133,5 +130,39 @@ class ShadowExceptionState(ErrorState):
     """Represents a shadow exception state."""
 
     def __init__(self):
-        super().__init__()
-        self.name = "SHADOW_EXCEPTION"
+        super().__init__("SHADOW_EXCEPTION")
+
+
+class JobSuspendedState(ErrorState):
+    """Represents if a suspended job state."""
+
+    def __init__(self):
+        super().__init__("JOB_SUSPENDED")
+
+
+class JobEvictedState(ErrorState):
+    """Represents an evicted job."""
+
+    def __init__(self):
+        super().__init__("JOB_EVICTED")
+
+
+class ExecutableErrorState(ErrorState):
+    """Represents an evicted job."""
+
+    def __init__(self):
+        super().__init__("EXECUTABLE_ERROR")
+
+
+class JobDisconnectedState(ErrorState):
+    """Represents a disconnected job state."""
+
+    def __init__(self):
+        super().__init__("JOB_DISCONNECTED")
+
+
+class JobReconnectFailedState(ErrorState):
+    """Represents if a job reconnect failed."""
+
+    def __init__(self):
+        super().__init__("JOB_RECONNECT_FAILED")


### PR DESCRIPTION
fixes partly #127 

Within the testset of `ukb, enki and git` htcondor logs, all events are handled.

The problem is that the documentation about how to access address each event individually is missing and there is no python baseclass to extract the information from. From what I understand is that the python structure is translated directly from the C++ base module, which has a total different setup and makes it hard to known where which part of the information is comming from.

Each event has a different struture which means each event needs to be handled differently.

There are base classes for the following event numbers that come with this PR:
- 000 - 013
- 022, 023, 024

Not (yet) handled events (regarding the base classes) are:
- 008 (does not do anything)
- 010 job suspended (no test data)
- 011 job unsuspended (no test data)
- 013 job released (no test data)
- 023 job reconnected (no test data)

And obviously all other events not mentioned here need also to be implemented